### PR TITLE
Allow the use of an IntrinsicElements Subset

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ type PropsWithAs<P, T extends React.ElementType> = P & { as?: T };
 export type PolymorphicPropsWithoutRef<
 	P, 
 	T extends React.ElementType, 
-	S extends keyof JSX.IntrinsicElements = JSX.IntrinsicElements
+	S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements
 > = Merge<
 	T extends keyof JSX.IntrinsicElements
 		? T extends S
@@ -23,7 +23,8 @@ export type PolymorphicPropsWithoutRef<
 export type PolymorphicPropsWithRef<
 	P, 
 	T extends React.ElementType, 
-	S extends keyof JSX.IntrinsicElements = JSX.IntrinsicElements> = Merge<
+	S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements
+> = Merge<
 	T extends keyof JSX.IntrinsicElements
 		? T extends S
       ? React.PropsWithRef<JSX.IntrinsicElements[T]>

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,13 @@ export {};
 
 type Merge<T, U> = Omit<T, keyof U> & U;
 
-type PropsWithAs<P, T extends React.ElementType> = P & { as?: T };
+type PropsWithAs<
+  P,
+  T extends React.ElementType,
+  S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
+> = P & {
+  as?: T extends keyof JSX.IntrinsicElements ? (T extends S ? T : never) : T
+};
 
 export type PolymorphicPropsWithoutRef<
 	P, 
@@ -13,11 +19,9 @@ export type PolymorphicPropsWithoutRef<
 	S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements
 > = Merge<
 	T extends keyof JSX.IntrinsicElements
-		? T extends S
-      ? React.PropsWithoutRef<JSX.IntrinsicElements[T]>
-      : never
+		? React.PropsWithoutRef<JSX.IntrinsicElements[T]>
 		: React.ComponentPropsWithoutRef<T>,
-	PropsWithAs<P, T>
+	PropsWithAs<P, T, S>
 >;
 
 export type PolymorphicPropsWithRef<
@@ -26,11 +30,9 @@ export type PolymorphicPropsWithRef<
 	S extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements
 > = Merge<
 	T extends keyof JSX.IntrinsicElements
-		? T extends S
-      ? React.PropsWithRef<JSX.IntrinsicElements[T]>
-      : never
+		? React.PropsWithRef<JSX.IntrinsicElements[T]>
 		: React.ComponentPropsWithRef<T>,
-	PropsWithAs<P, T>
+	PropsWithAs<P, T, S>
 >;
 
 // TODO:

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,16 +7,27 @@ type Merge<T, U> = Omit<T, keyof U> & U;
 
 type PropsWithAs<P, T extends React.ElementType> = P & { as?: T };
 
-export type PolymorphicPropsWithoutRef<P, T extends React.ElementType> = Merge<
+export type PolymorphicPropsWithoutRef<
+	P, 
+	T extends React.ElementType, 
+	S extends keyof JSX.IntrinsicElements = JSX.IntrinsicElements
+> = Merge<
 	T extends keyof JSX.IntrinsicElements
-		? React.PropsWithoutRef<JSX.IntrinsicElements[T]>
+		? T extends S
+      ? React.PropsWithoutRef<JSX.IntrinsicElements[T]>
+      : never
 		: React.ComponentPropsWithoutRef<T>,
 	PropsWithAs<P, T>
 >;
 
-export type PolymorphicPropsWithRef<P, T extends React.ElementType> = Merge<
+export type PolymorphicPropsWithRef<
+	P, 
+	T extends React.ElementType, 
+	S extends keyof JSX.IntrinsicElements = JSX.IntrinsicElements> = Merge<
 	T extends keyof JSX.IntrinsicElements
-		? React.PropsWithRef<JSX.IntrinsicElements[T]>
+		? T extends S
+      ? React.PropsWithRef<JSX.IntrinsicElements[T]>
+      : never
 		: React.ComponentPropsWithRef<T>,
 	PropsWithAs<P, T>
 >;
@@ -35,7 +46,7 @@ type PolymorphicExoticComponent<
 		 * **NOTE**: Exotic components are not callable.
 		 */
 		<InstanceT extends React.ElementType = T>(
-			props: PolymorphicPropsWithRef<P, InstanceT>,
+			props: PolymorphicPropsWithRef<P, InstanceT, T>,
 		): React.ReactElement | null;
 	}
 >;


### PR DESCRIPTION
This PR allows the use of a subset of the `JSX.IntrinsicElements`. 

The use case is for example:

```ts
import type { PolymorphicPropsWithoutRef } from "react-polymorphic-types";

// An HTML tag or a different React component can be rendered by default
export const HeadingDefaultElement = "h2";
// The list of the jsx nodes allowed
export type HeadingAllowedElements = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'

// Component-specific props should be specified separately
export type HeadingOwnProps = {
  color?: string;
};

// Extend own props with others inherited from the underlying element type
// Own props take precedence over the inherited ones
export type HeadingProps<
  T extends React.ElementType = typeof HeadingDefaultElement
> = PolymorphicPropsWithoutRef<HeadingOwnProps, T, HeadingAllowedElements>;

export function Heading<
  T extends React.ElementType = typeof HeadingDefaultElement
>({ as, color, style, ...restProps }: HeadingProps<T>) {
  const Element: React.ElementType = as || HeadingDefaultElement;
  return <Element style={{ color, ...style }} {...restProps} />;
}
```

@kripod Probably this PR needs a bit more work to make it backward compatible but let me know if you are interested into this feature.