### PR TITLE
fix: missing types with "moduleResolution": "Node16"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 	"sideEffects": false,
 	"exports": {
 		"default": "./empty.js",
-		"import": "./empty.js"
+		"import": "./empty.js",
+		"types": "./index.d.ts"
 	},
 	"main": "./empty.js",
 	"types": "./index.d.ts",


### PR DESCRIPTION
Since the filename pointed at by `default` and `import` (`empty`) is not identical to the filename of the `d.ts` file (`index`), the top level `types` field is not enough when using `"moduleResolution": "Node16"` and TypeScript `4.7`. 

To fix this, `types` must be explicitly specified inside the `exports` object in addition to the top level `types` field.

See [firebase/firebase-js-sdk#6300](/firebase/firebase-js-sdk/issues/6300) and [microsoft/playwright#14428](/microsoft/playwright/pull/14428)