### PR TITLE
fix: update return type for @types/react

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ type PolymorphicExoticComponent<
 		 */
 		<InstanceT extends React.ElementType = T>(
 			props: PolymorphicPropsWithRef<P, InstanceT>,
-		): React.ReactElement | null;
+		): React.ReactNode | null;
 	}
 >;
 


### PR DESCRIPTION
## Issue
In `@types/react` version 2.14 (could have started earlier), the return type of `PolymorphicForwardRefExoticComponent` started being incorrect causing a TS error. 

## Example code
```tsx
import type {
  PolymorphicForwardRefExoticComponent,
  PolymorphicPropsWithRef,
  PolymorphicPropsWithoutRef,
} from 'react-polymorphic-types'

type BaseButtonDefaultElement = 'button'

const PrimaryButton: PolymorphicForwardRefExoticComponent<
  PrimaryButtonProps,
  BaseButtonDefaultElement
> = forwardRef(function PrimaryButton<T extends React.ElementType = BaseButtonDefaultElement>(
  props: PolymorphicPropsWithoutRef<PrimaryButtonProps, T>,
  ref: React.ForwardedRef<Element>,
) {
  ...
}
```

## Example error

```ts
Type 'ForwardRefExoticComponent<Omit<Omit<SVGProps<SVGSymbolElement>, "ref"> | Omit<DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>, "ref"> | ... 121 more ... | Omit<...>, keyof BaseButtonCommonProps | ... 3 more ... | "as"> & PrimaryButtonProps & { ...; } & RefAttributes<...>>' is not assignable to type 'PolymorphicForwardRefExoticComponent<PrimaryButtonProps, "button">'.
  Type 'ForwardRefExoticComponent<Omit<Omit<SVGProps<SVGSymbolElement>, "ref"> | Omit<DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>, "ref"> | ... 121 more ... | Omit<...>, keyof BaseButtonCommonProps | ... 3 more ... | "as"> & PrimaryButtonProps & { ...; } & RefAttributes<...>>' is not assignable to type '<InstanceT extends ElementType<any> = "button">(props: PolymorphicPropsWithRef<PrimaryButtonProps, InstanceT>) => ReactElement<any, string | JSXElementConstructor<...>> | null'.
    Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | null'.
      Type 'undefined' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | null'.ts(2322)
```

## Proposed solution
When changing it to return `React.ReactNode` instead of `React.ReactElement`, the type error goes away. I've tested this in our internal codebase and everything seems to work as expected.